### PR TITLE
Change size of latex on answer card

### DIFF
--- a/ankdown/ankdown.py
+++ b/ankdown/ankdown.py
@@ -84,7 +84,7 @@ class Card(object):
             {
                 "name": "Ankdown Card",
                 "qfmt": "{{Question}}",
-                "afmt": "{{FrontSide}}<hr id='answer'>{{Answer}}",
+                "afmt": "{{FrontSide}}<hr id='answer'><div class='latex-front'>{{Answer}}</div>",
             },
         ],
         css="""
@@ -98,6 +98,10 @@ class Card(object):
 
         .latex {
             height: 0.8em;
+        }
+        
+        .latex-front {
+            height: 5.0em;
         }
         """,
     )


### PR DESCRIPTION
On desktop Anki, the latex displayed in the answer cards is too small by default. This just adds a bit of css to make it bigger - this might need some tweaks to make sure it still looks okay on Anki mobile as well.